### PR TITLE
Add `package` JSON, with `private: true` set

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
+package-lock.json
 .DS_Store
 
 # Logs

--- a/example/index.html
+++ b/example/index.html
@@ -2,11 +2,14 @@
 <html>
 <head>
 	<title>Exampler</title>
+
+	<style> body { font:1rem sans-serif; text-align:center; } button { font-size:2rem; margin: 1rem; } </style>
 </head>
 <body>
+	<h1>Exampler</h1>
 
-	<script src="https://cdnjs.cloudflare.com/ajax/libs/tone/13.3.1/Tone.min.js"></script>
-	<script src="scribbletune.js"></script>
+	<script src="https://cdnjs.cloudflare.com/ajax/libs/tone/13.8.28/Tone.js"></script>
+	<script src="scribbletune.js?v=1.5.3-rc.1"></script>
 	<script src="../index.js"></script>
 	<script src="../tone-mono-synths.js"></script>
 	<script src="script.js"></script>

--- a/example/script.js
+++ b/example/script.js
@@ -1,4 +1,4 @@
-(async () => {
+(async (DOC, scribble, Tone) => {
 	const key = 'F';
 	const scale = 'minor';
 
@@ -10,7 +10,7 @@
 	scribble.clip({
 		notes: getNotes(key, 3, scale),
 		pattern: '[xx]',
-		instrument: getToneMonoSynth('MonoSynth:BassGuitar') 
+		instrument: getToneMonoSynth('MonoSynth:BassGuitar')
 	}).start();
 
 	scribble.clip({
@@ -18,14 +18,13 @@
 		pattern: 'xx[-x]'.repeat(3) + 'xx[xx]',
 		// In the following method '/samples/' is explicitly set as the second argument
 		// because we are using a custom location for it
-		// In most cases you ll just clone this repo in your public/ folder and if you did that, 
+		// In most cases you'll just clone this repo in your public/ folder and if you did that,
 		// the default location would be used and you wont need to specify the second argument
 		// sampler: await getSampler('korgBass', '/samples/')
 		sampler: await getSampler('superSaw', '/samples/'),
 		volume: -18,
 		effects: ['Chorus']
 	}).start();
-
 
 	scribble.clip({
 		notes: scribble.progression(key + '3 ' + scale, 'i VII VI VII'),
@@ -48,17 +47,15 @@
 
 	Tone.Transport.bpm.value = 145;
 
-	const btnStart = document.createElement('button');
-	btnStart.innerHTML = 'Start';
-	document.body.appendChild(btnStart);
-	btnStart.onclick = function() {
-		Tone.Transport.start();
-	};
+	createButtonClick('Start', ev => Tone.Transport.start());
+	createButtonClick('Stop',  ev => Tone.Transport.stop() );
 
-	const btnStop = document.createElement('button');
-	btnStop.innerHTML = 'Stop';
-	document.body.appendChild(btnStop);
-	btnStop.onclick = function() {
-		Tone.Transport.stop();
-	};
-})();
+	function createButtonClick(label, eventHandler) {
+		const button = DOC.createElement('button');
+		button.innerHTML = label;
+		button.onclick = ev => eventHandler(ev); // Tone.Transport[ callbackFn ]();
+
+		DOC.body.appendChild(button);
+	}
+
+})(window.document, window.scribble, window.Tone);

--- a/index.js
+++ b/index.js
@@ -1,6 +1,8 @@
 const getSampler = (sampler, baseUrl='/sampler/samples/') => {
   return new Promise(resolve => {
-    const smplr = new Tone.Sampler(samplers[sampler], function() { 
+    const smplr = new Tone.Sampler(samplers[sampler], function() {
+      smplr.x_name = sampler;
+      smplr.x_baseUrl = baseUrl;
       return resolve(smplr);
     }, baseUrl);
   });

--- a/package.json
+++ b/package.json
@@ -1,0 +1,20 @@
+{
+  "private": true,
+  "name": "@scribbletune/sampler",
+  "version": "1.0.0",
+  "description": "[WIP] Samplers, Tone.js mono synths and sounds for Scribbletune Live!",
+  "main": "./index.js",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/scribbletune/sampler.git"
+  },
+  "author": "Walmik Deshpande",
+  "license": "MIT",
+  "scripts": {
+    "start": "npx live-server --port=9001 --no-browser # -> /example/"
+  },
+  "peerDependencies": {
+    "tone": "^13.8.28",
+    "live-server": "^1.2.1"
+  }
+}


### PR DESCRIPTION
Hi @walmik,

I've added a `package.json` file to this repository, so that it can be re-used, via:

```sh
npm install https://github.com/scribbletune/sampler.git
```

I also defined a `start` script ... `npm start`

```sh
npx live-server --port=9001 --no-browser
```

Plus, I updated the `Tone.js` peer / CDN dependency to 13.8.28.

Best wishes,


Nick